### PR TITLE
Update PullRequestLinuxGCC4.9.3TestingSettings.cmake

### DIFF
--- a/cmake/std/PullRequestLinuxGCC4.9.3TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC4.9.3TestingSettings.cmake
@@ -19,3 +19,7 @@ set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default f
 set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
+
+#Adding warnings as errors flags to this PR build
+#This should fail. Plan to break down package by package
+set (CMAKE_CXX_FLAGS "-Wall -ansi -pedantic -Werror -Wno-unknown-pragmas -Wno-narrowing -Wno-pragmas -Wno-delete-non-virtual-dtor")


### PR DESCRIPTION
@trilinos/framework

## Description
Setting warnings as errors flags for MPI GCC 4.9.3 build. This should be too aggressive and fail, but I want to baseline through testing.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
We want to keep warnings out of clean packages. We will need to do that on a package by package basis, but first I want to baseline where we are at.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
